### PR TITLE
Add level, time, and name to default format

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This gives you `--verbosity`, `--silent`, and `--logdev` options.
 ```python
 import logmuse
 
+
 def main():
     # ... parse args ...
     logger = logmuse.logger_via_cli(args, make_root=True)
@@ -57,6 +58,7 @@ Imported packages don't need logmuse at all. Just use the standard `logging` mod
 
 ```python
 import logging
+
 _LOGGER = logging.getLogger(__name__)
 ```
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.1] -- 2026-08-07
+### Changed
+- Default (non-devmode) log message format now includes level, timestamp, and logger name: `[%(levelname)s] [%(asctime)s] [%(name)s] %(message)s` (was bare `%(message)s`). This is what downstream packages were reconfiguring by hand.
+- Because the logger name is now included, downstream packages no longer need to hand-roll a per-package prefix (e.g. `[BEDBOSS]`, `[PEPDBAGENT]`) in their own format strings; `%(name)s` reports the actual originating logger, including submodules.
+- Development mode (`--logdev`/`devmode=True`) and log file output formats are unchanged.
+
 ## [0.3.0] -- 2026-03-05
 ### Changed
 - Modernized packaging: pyproject.toml with hatchling, removed setup.py

--- a/logmuse/logmuse.py
+++ b/logmuse/logmuse.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-BASIC_LOGGING_FORMAT: str = "%(message)s"
+BASIC_LOGGING_FORMAT: str = "[%(levelname)s] [%(asctime)s] [%(name)s] %(message)s"
 DEV_LOGGING_FMT: str = (
     "%(levelname).4s %(asctime)s | %(name)s:%(module)s:%(lineno)d > %(message)s "
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logmuse"
-version = "0.3.0"
+version = "0.3.1"
 description = "Logging setup"
 readme = "README.md"
 license = "BSD-2-Clause"


### PR DESCRIPTION
logmuse's default log format was a bare `%(message)s`, so a log line showed no level, no timestamp, and no indication of where it came from. Almost every package downstream fixed that itself by calling `coloredlogs.install()` with its own format string, and they all wrote roughly the same thing.

There are about thirteen of those calls across pepdbagent, geopephub, pephubclient, bedboss, and pephub. Reaching for `coloredlogs.install()` to set a format is also how those packages ended up configuring logging at import time, which is a separate problem we are currently cleaning up.

This changes the default to include the level, the time, and the logger name:

    [INFO] [13:31:14] [geopephub.metageo_pephub] GSE: 'GSE12345' was added to the queue

The logger name deserves a note. Several packages were hardcoding a per-package tag like `[BEDBOSS]` or `[PEPDBAGENT]` into their format strings, which is just the logger name written out by hand. `%(name)s` gives the same thing automatically, and gives the real originating logger rather than a fixed label, so submodules identify themselves. Downstream packages can drop those tags entirely.

Developer mode and log file output are unchanged, and passing an explicit `fmt` still overrides the default.

This does make output wider, and it changes what every logmuse user sees. Worth a look before it goes out.